### PR TITLE
modified parsing of host parameter to also evaluate the port

### DIFF
--- a/_client.js
+++ b/_client.js
@@ -9,7 +9,8 @@ if (argv.trace) {
 
 clientConfig.hosts = [
   {
-    host: argv.host,
+    host: argv.host.split(":")[0],
+    port: argv.host.split(":")[1] ? argv.host.split(":")[1] : "9200",
     auth: argv.auth
   }
 ];


### PR DESCRIPTION
The online help specified that host and port are to be specified with the host param (`--host, -h      The host name and port`), but the code only sets the host part of the elasticsearch client config.

With this patch both, host and port, are used for the client config.